### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/SignalRDemo/src/SignalRDemo.Web/Pages/Chat.js
+++ b/SignalRDemo/src/SignalRDemo.Web/Pages/Chat.js
@@ -21,7 +21,12 @@
         connection.invoke("SendMessage", targetUserName, message)
             .then(function() {
                 $('#MessageList')
-                    .append('<li><i class="fas fa-long-arrow-alt-left"></i> ' + abp.currentUser.userName + ': ' + message + '</li>');
+                    .append(
+                        $('<li>')
+                            .append('<i class="fas fa-long-arrow-alt-left"></i> ')
+                            .append(document.createTextNode(abp.currentUser.userName + ': '))
+                            .append(document.createTextNode(message))
+                    );
             })
             .catch(function(err) {
                 return console.error(err.toString());

--- a/SignalRTieredDemo/src/SignalRTieredDemo.Web/Pages/Chat.js
+++ b/SignalRTieredDemo/src/SignalRTieredDemo.Web/Pages/Chat.js
@@ -24,8 +24,9 @@
             targetUserName: targetUserName,
             message: message
         }).then(function() {
-            $('#MessageList')
-                .append('<li><i class="fas fa-long-arrow-alt-left"></i> ' + abp.currentUser.userName + ': ' + message + '</li>');
+            var $li = $('<li>');
+            $li.append($('<i>').addClass('fas fa-long-arrow-alt-left')).append(' ' + abp.currentUser.userName + ': ').append(document.createTextNode(message));
+            $('#MessageList').append($li);
         });
 
     });


### PR DESCRIPTION
Potential fix for [https://github.com/FrontisBV/abp-samples/security/code-scanning/1](https://github.com/FrontisBV/abp-samples/security/code-scanning/1)

To address the XSS risk, user-supplied input (i.e., the message text) must not be inserted into HTML using string concatenation and `.append()` with an HTML string. The best practice is to create the new DOM elements using either the jQuery DOM API or by ensuring the user content is properly escaped/encoded for HTML context before insertion.

The simplest and correct fix here is:
- Use jQuery's DOM methods to build the new list item (`<li>`), using `.text()` or passing the message as a text node so that it is not interpreted as HTML, but as plain text.
- The same applies to the username if it could ever contain untrusted data.
- Only non-user-controlled markup/icons should be part of any HTML string.

Thus, we should create the `<li>` and its children via jQuery, and insert the untrusted `message` value using `.text()`.

**Required changes:**
- Change line 24 to build the `<li>` using jQuery, insert icons/markup as HTML, but insert user data (like message and username) as text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
